### PR TITLE
Make local files work

### DIFF
--- a/update-manifest.js
+++ b/update-manifest.js
@@ -14,7 +14,7 @@ const jsEntrypoint = assetManifest.entrypoints.filter((file) =>
 const contentScripsOtps = {
   content_scripts: [
     {
-      matches: ["*://*/*/-/jobs/*/raw", "*://*/*/*/*/*/*/*/job.log*", "https://storage.googleapis.com/gitlab-gprd-artifacts/*/job.log*"],
+      matches: ["*://*/*/-/jobs/*/raw", "*://*/*/*/*/*/*/*/job.log*", "https://storage.googleapis.com/gitlab-gprd-artifacts/*/job.log*", "file:///*job.log"],
       css: cssEntrypoints,
       js: jsEntrypoint,
     },


### PR DESCRIPTION
This PR adds local path regex to the existing matches. Useful when we have to download the raw file from server and view it locally.